### PR TITLE
Use Travis CI for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+- 9.11.1
+jobs:
+  include:
+  - script: npm run build
+branches:
+  only:
+  - master
+  - "/^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:\\-(rc\\.[0-9]+)*)?$/"


### PR DESCRIPTION
This uses Travis CI to ensure PRs successfully build, at least.

Later on we’ll enforce test-passing (#10), and possibly automated NPM deploys. Possibly.

Closes #12.