### PR TITLE
SVG Placeholders are blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ low-quality image placeholders (LQIP) for loading.
 
 | Filetype | Resizing | Optimization | Converting to |
 | :------- | :------: | :----------: | :-----------: |
-| JPG      |    ✅    |      ✅      |      ✅       |
-| PNG      |    ✅    | ⚠️ **SLOW**  |  ⚠️ **SLOW**  |
-| WebP     |    ✅    |      ✅      |      ✅       |
-| SVG      |   N/A    |      ✅      |      N/A      |
-| GIF      |    🚫    |      ✅      |      🚫       |
+| JPG      | ✅        | ✅            | ✅             |
+| PNG      | ✅        | ⚠️ **SLOW**  | ⚠️ **SLOW**   |
+| WebP     | ✅        | ✅            | ✅             |
+| SVG      | N/A      | ✅            | N/A           |
+| GIF      | 🚫       | ✅            | 🚫            |
 
 _Note: GIF resizing/conversion isn’t supported due to lack of support in
 [sharp][sharp]. Overall, it’s a small price to pay for the build speed of the
@@ -147,10 +147,18 @@ import pixelArt from './pixel-art?w=2048&interpolation=nearest';
 import image from './myimage.jpg?w=1200';
 import placeholder from './myimage.jpg?placeholder';
 
-<div style={{ backgroundImage: `url(${placeholder})` }}>
+<div style={{ backgroundImage: `url(${placeholder}), backgroundSize: 'cover'` }}>
   <img src={image} />
 </div>;
 ```
+
+Due to the nature of SVG the placeholder will be small, but it will preserve
+its aspect ratio if used in an `<img>` tag and is made to be expanded. Either
+use `width: 100%; height: auto` to fill the area, or `background-size` to
+make it larger.
+
+An SVG placeholder is used to avoid that white fuzzy border caused by CSS’
+blur filter on normal images.
 
 _Note: placeholders can’t be generated for SVGs_
 
@@ -163,20 +171,20 @@ webpack config as your images change.
 
 ### Query Options
 
-| Name            | Default    | Description                                                                                                                                                                                                                                                                                                                                |
-| :-------------- | :--------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `width`         | (original) | Set image width (in pixels). Leave `height` blank to auto-scale. Specify `width` and `height` to ensure image is smaller than both.                                                                                                                                                                                                        |
-| `w`             |            | Shortcut for `width`.                                                                                                                                                                                                                                                                                                                      |
-| `height`        | (original) | Scale image height (in pixels). Leave `width` blank to auto-scale. Specify `width` and `height` to ensure image is smaller than both.                                                                                                                                                                                                      |
-| `h`             |            | Shortcut for `height`.                                                                                                                                                                                                                                                                                                                     |
-| `quality`       | `70`       | Specify `1`–`100` to set the image’s quality<sup>\*</sup>. For each image, set it as low as possible before compression is noticeable at display size.                                                                                                                                                                                     |
-| `q`             |            | Shortcut for `quality`.                                                                                                                                                                                                                                                                                                                    |
+| Name            | Default    | Description                                                                                                                                                                                                                                                                                                                                   |
+| :-------------- | :--------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `width`         | (original) | Set image width (in pixels). Leave `height` blank to auto-scale. Specify `width` and `height` to ensure image is smaller than both.                                                                                                                                                                                                           |
+| `w`             |            | Shortcut for `width`.                                                                                                                                                                                                                                                                                                                         |
+| `height`        | (original) | Scale image height (in pixels). Leave `width` blank to auto-scale. Specify `width` and `height` to ensure image is smaller than both.                                                                                                                                                                                                         |
+| `h`             |            | Shortcut for `height`.                                                                                                                                                                                                                                                                                                                        |
+| `quality`       | `70`       | Specify `1`–`100` to set the image’s quality<sup>\*</sup>. For each image, set it as low as possible before compression is noticeable at display size.                                                                                                                                                                                       |
+| `q`             |            | Shortcut for `quality`.                                                                                                                                                                                                                                                                                                                       |
 | `interpolation` | `'cubic'`  | When scaling, specify `'nearest'` for nearest-neighbor (pixel art), `'cubic'` for cubic interpolation, or `'lanczos2'` or `'lanczos3'` for [Lanczos][lanczos] with `a=2` or `a=3`. `'cubic'` is this loader’s default (because it’s what most are used to), as opposed to`'lanczos3'` which is sharp’s default (present for other loaders) |
-| `inline`        | `false`    | Set to `?inline` or `?inline=true` to return the individual image in base64 data URI, or raw SVG code 🎉.                                                                                                                                                                                                                                  |
-| `format`        | (same)     | Specify `jpg`, `webp`, or `png` to convert format from the original.                                                                                                                                                                                                                                                                       |
-| `f`             |            | Shortcut for `format`.                                                                                                                                                                                                                                                                                                                     |
-| `placeholder`   | `false`    | Specify `?placeholder` to return a low-quality image placeholder (technically this can be used alongside other options, but it’s not advised).                                                                                                                                                                                             |
-| `skip`          | `false`    | Set to `?skip` to bypass resizing & optimization entirely. This is particularly useful for SVGs that don’t optimize well.                                                                                                                                                                                                                  |
+| `inline`        | `false`    | Set to `?inline` or `?inline=true` to return the individual image in base64 data URI, or raw SVG code 🎉.                                                                                                                                                                                                                                     |
+| `format`        | (same)     | Specify `jpg`, `webp`, or `png` to convert format from the original.                                                                                                                                                                                                                                                                          |
+| `f`             |            | Shortcut for `format`.                                                                                                                                                                                                                                                                                                                        |
+| `placeholder`   | `false`    | Specify `?placeholder` to return a low-quality image placeholder (technically this can be used alongside other options, but it’s not advised).                                                                                                                                                                                               |
+| `skip`          | `false`    | Set to `?skip` to bypass resizing & optimization entirely. This is particularly useful for SVGs that don’t optimize well.                                                                                                                                                                                                                    |
 
 _<sup>\*</sup> Note: GIFsicle and OptiPNG don’t use a 1–100 quality scale, so
 `quality` will convert for you. However, if using loader options below, you’ll
@@ -199,16 +207,16 @@ inline, but there are some settings which make sense to set globally, such as
 [SVGO][svgo] settings, or a fallback quality. In these cases, pass options to
 the loader as usual:
 
-| Name         | Default             | Description                                                                                        |
-| :----------- | :------------------ | :------------------------------------------------------------------------------------------------- |
+| Name         | Default             | Description                                                                                         |
+| :----------- | :------------------ | :-------------------------------------------------------------------------------------------------- |
 | `outputPath` | `output.path`       | Override webpack’s default output path for these images (setting from [file-loader][file-loader]). |
 | `publicPath` | `output.publicPath` | Override webpack’s default output path for these images (setting from [file-loader][file-loader]). |
-| `emitFile`   | `true`              | Set to `false` to skip processing file (setting from [file-loader][file-loader]).                  |
-| `gifsicle`   | (object)            | Specify Gifsicle options ([view options][gifsicle-options]).                                       |
-| `mozjpeg`    | (object)            | Specify mozjpeg options ([view options][mozjpeg-options]).                                         |
-| `optipng`    | (object)            | Specify OptiPNG options ([view options][optipng-options]).                                         |
-| `pngquant`   | (object)            | Specify PNGquant options ([view options][pngquant-options]).                                       |
-| `svgo`       | (object)            | Specify [SVGO][svgo] options.                                                                      |
+| `emitFile`   | `true`              | Set to `false` to skip processing file (setting from [file-loader][file-loader]).                   |
+| `gifsicle`   | (object)            | Specify Gifsicle options ([view options][gifsicle-options]).                                        |
+| `mozjpeg`    | (object)            | Specify mozjpeg options ([view options][mozjpeg-options]).                                          |
+| `optipng`    | (object)            | Specify OptiPNG options ([view options][optipng-options]).                                          |
+| `pngquant`   | (object)            | Specify PNGquant options ([view options][pngquant-options]).                                        |
+| `svgo`       | (object)            | Specify [SVGO][svgo] options.                                                                       |
 
 _Note: because this loader passes images on to [file-loader][file-loader],
 you should be able to use any of its options within this config. However,
@@ -297,6 +305,16 @@ for images. This loader prioritizes practical image handling over webpack’s
 loader philosophy, allowing you to take the same file extension and serve it
 multiple different ways depending on the need.
 
+### LQIP (placeholder images) aren’t showing!
+
+The placeholder SVGS are compressed further by
+[mini-svg-data-uri][mini-svg-data-uri], which requires **double quotes** for
+`<img src="[placeholder]" />` and `background-image: url("[placeholder]")`.
+Check to make sure your code is outputting double quotes in HTML/CSS.
+
+The tradeoff is much smaller bundles, and better GZIP performance without
+sacrificing browser support.
+
 ## Special Thanks
 
 This loader wouldn’t be possible without the significant achievements of:
@@ -306,6 +324,7 @@ This loader wouldn’t be possible without the significant achievements of:
 * [@kevva][@kevva] for [imagemin][imagemin]
 * [@sokra][@sokra], [@d3viant0ne][@d3viant0ne], and [@michael-ciniawsky][@michael-ciniawsky] for [file-loader][file-loader]
 * [@lovell][@lovell] for [sharp][sharp]
+* [@tigt][@tigt] for [mini-svg-data-uri][mini-svg-data-uri]
 
 [@dcommander]: https://github.com/dcommander
 [@d3viant0ne]: https://github.com/d3viant0ne
@@ -314,7 +333,9 @@ This loader wouldn’t be possible without the significant achievements of:
 [@lovell]: https://github.com/lovell
 [@michael-ciniawsky]: https://github.com/michael-ciniawsky
 [@sokra]: https://github.com/sokra
+[@tigt]: https://github.com/tigt
 [csstricks]: https://css-tricks.com/using-webp-images/
+[mini-svg-data-uri]: https://github.com/tigt/mini-svg-data-uri
 [file-loader]: https://github.com/webpack-contrib/file-loader
 [gifsicle]: https://github.com/imagemin/imagemin-gifsicle
 [gifsicle-options]: https://github.com/dangodev/lightspeed-image-loader/wiki/Gifsicle-Settings

--- a/README.md
+++ b/README.md
@@ -210,10 +210,9 @@ the loader as usual:
 | `pngquant`   | (object)            | Specify PNGquant options ([view options][pngquant-options]).                                       |
 | `svgo`       | (object)            | Specify [SVGO][svgo] options.                                                                      |
 
-\_Note: because this loader passes images on to [file-loader][file-loader],
-you should be able to use any options from file-loader loaders within this
-config. However,
-**don’t use this loader for anything other than images!**
+_Note: because this loader passes images on to [file-loader][file-loader],
+you should be able to use any of its options within this config. However,
+**don’t use this loader for anything other than images!**_
 
 #### Example
 
@@ -292,22 +291,26 @@ Two reasons: first, image optimization / resizing has a particular order that
 needs to be kept: resizing first, then optimization. Always. If there’s only
 one proper order for images, and if one loader does it all, why chain?
 
-Second, and more importantly, webpack can only pass a file through a loader
-based on `test` (which typically coincides with extension). So you couldn’t,
-say, take one `.jpg` file and output a URL, and take another `.jpg` file and
-output an inline base64-encoded version. You’d need to handle every extension
-the same way. This gives you the freedom to handle each image differently.
+Second, and more importantly, webpack doesn’t make it easy to handle the same
+file extension in different ways. This makes sense for, say, JS, but less so
+for images. This loader prioritizes practical image handling over webpack’s
+loader philosophy, allowing you to take the same file extension and serve it
+multiple different ways depending on the need.
 
 ## Special Thanks
 
 This loader wouldn’t be possible without the significant achievements of:
 
+* [@dcommander][@dcommander] for [mozjpeg][mozjpeg]
+* [@kornelski][@kornelski] for [pngquant][pngquant]
 * [@kevva][@kevva] for [imagemin][imagemin]
 * [@sokra][@sokra], [@d3viant0ne][@d3viant0ne], and [@michael-ciniawsky][@michael-ciniawsky] for [file-loader][file-loader]
 * [@lovell][@lovell] for [sharp][sharp]
 
+[@dcommander]: https://github.com/dcommander
 [@d3viant0ne]: https://github.com/d3viant0ne
 [@kevva]: https://github.com/kevva
+[@kornelski]: https://github.com/kornelski
 [@lovell]: https://github.com/lovell
 [@michael-ciniawsky]: https://github.com/michael-ciniawsky
 [@sokra]: https://github.com/sokra

--- a/examples/react/index.js
+++ b/examples/react/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 
 import jpg from './original.jpg?quality=50&w=200';
 import jpgDupe from './original.jpg?q=50&width=200';
-import jpgLarge from './original.jpg?quality=80&w=500';
+import jpgLarge from './original.jpg?quality=80&w=1400';
 import jpgInline from './original.jpg?inline&q=80&w=500';
 import jpgToPNG from './original.jpg?f=png';
 import jpgToWebP from './original.jpg?f=webp&w=1200';
@@ -15,11 +15,7 @@ import skip from './original.jpg?skip';
 import pixelArt from './pixel-art.png?w=500&interpolation=linear';
 import placeholder from './original.jpg?placeholder';
 
-console.log(svgInline);
-
-const inlineSVG = () => ({
-  __html: svgInline,
-});
+const inlineSVG = () => ({__html: svgInline});
 
 const App = () => (
   <div>
@@ -47,7 +43,7 @@ const App = () => (
     <img src={pixelArt} />
     <div
       style={{
-        backgroundImage: `url(${placeholder})`,
+        backgroundImage: `url("${placeholder}")`,
         backgroundPosition: 'center',
         backgroundRepeat: 'no-repeat',
         backgroundSize: 'cover',

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -4,17 +4,17 @@
     "start": "webpack-serve --config webpack.dev.js"
   },
   "dependencies": {
-    "react": "^16.3.1",
-    "react-dom": "^16.3.1"
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2"
   },
   "devDependencies": {
-    "babel-core": "^6.26.0",
+    "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
     "babel-preset-react": "^6.24.1",
     "copy-webpack-plugin": "^4.5.1",
-    "webpack": "^4.5.0",
-    "webpack-cli": "^2.0.14",
+    "webpack": "^4.8.2",
+    "webpack-cli": "^2.1.3",
     "webpack-merge": "^4.1.2",
-    "webpack-serve": "^0.3.1"
+    "webpack-serve": "^0.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightspeed-image-loader",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "webpack loader for optimized, responsive images. Works with React, Vue, and all frontend setups.",
   "main": "dist",
   "files": [
@@ -42,6 +42,7 @@
     "imagemin-pngquant": "^5.1.0",
     "imagemin-svgo": "^6.0.0",
     "imagemin-webp": "^4.1.0",
+    "mini-svg-data-uri": "^1.0.0",
     "raw-loader": "^0.5.1",
     "sharp": "^0.20.2"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "performance"
   ],
   "dependencies": {
-    "chalk": "^2.3.2",
+    "chalk": "^2.4.1",
     "file-loader": "^1.1.11",
     "imagemin": "^5.3.1",
     "imagemin-gifsicle": "^5.2.0",
@@ -41,14 +41,14 @@
     "imagemin-svgo": "^6.0.0",
     "imagemin-webp": "^4.1.0",
     "raw-loader": "^0.5.1",
-    "sharp": "^0.20.1"
+    "sharp": "^0.20.2"
   },
   "devDependencies": {
-    "@babel/cli": "^7.0.0-beta.44",
-    "@babel/core": "^7.0.0-beta.44",
-    "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.44",
-    "@babel/preset-env": "^7.0.0-beta.44",
-    "babel-eslint": "^8.2.2",
+    "@babel/cli": "^7.0.0-beta.46",
+    "@babel/core": "^7.0.0-beta.46",
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.46",
+    "@babel/preset-env": "^7.0.0-beta.46",
+    "babel-eslint": "^8.2.3",
     "eslint": "^4.19.1",
     "eslint-config-google": "^0.9.1",
     "loader-utils": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "dist"
   ],
   "scripts": {
+    "prebuild": "npm run lint",
     "build": "babel src -d dist --ignore 'src/**/*.test.js' --copy-files",
     "build:watch": "babel src -d dist --ignore 'src/**/*.test.js' --copy-files --watch",
+    "lint": "eslint src --ignore-pattern src/config",
     "test": "test"
   },
   "repository": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,15 @@
+const DEFAULT_QUALITY = 70; // %
+const LQIP_WIDTH = 32; // px
+const MIME_TYPES = {
+  gif: 'image/gif',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+};
+
+module.exports = {
+  DEFAULT_QUALITY,
+  LQIP_WIDTH,
+  MIME_TYPES,
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,6 +2,7 @@ const DEFAULT_QUALITY = 70; // %
 const LQIP_WIDTH = 32; // px
 const MIME_TYPES = {
   gif: 'image/gif',
+  jpeg: 'image/jpeg',
   jpg: 'image/jpeg',
   png: 'image/png',
   svg: 'image/svg+xml',

--- a/src/format.js
+++ b/src/format.js
@@ -1,0 +1,11 @@
+const sharp = require('sharp');
+
+module.exports = ({context, extension, format, pathname, ...options}) => {
+  if (extension === 'svg' || extension === 'gif' || !format) return pathname;
+  // Shim for file-loader renaming
+  context.resourcePath = context.resourcePath.replace(
+    /\.[^.]+$/,
+    `.${extension}`
+  );
+  return sharp(pathname).toFormat(format, options.sharp[format]);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,185 +1,59 @@
 const chalk = require('chalk');
 const fs = require('fs');
 const fileLoader = require('file-loader');
-const imagemin = require('imagemin');
-const imageminGifsicle = require('imagemin-gifsicle');
-const imageminMozjpeg = require('imagemin-mozjpeg');
-const imageminOptiPng = require('imagemin-optipng');
-const imageminPngQuant = require('imagemin-pngquant');
-const imageminSVGO = require('imagemin-svgo');
-const imageminWebP = require('imagemin-webp');
 const {getOptions, parseQuery} = require('loader-utils');
 const rawLoader = require('raw-loader');
 const sharp = require('sharp');
 const validateOptions = require('schema-utils');
 
 const fileSchema = require('./config/file.json');
-const gifsicleDefaults = require('./config/gifsicle');
 const loaderSchema = require('./config/loader.json');
-const mozjpegDefaults = require('./config/mozjpeg');
-const optipngDefaults = require('./config/optipng');
-const pngquantDefaults = require('./config/pngquant');
-const webpDefaults = require('./config/webp');
 
-/* Constants */
+const format = require('./format');
+const lqip = require('./lqip');
+const optimize = require('./optimize');
+const resize = require('./resize');
 
-const DEFAULT_QUALITY = 70;
-const LQIP_WIDTH = 32; // in px
-const MIME_TYPES = {
-  gif: 'image/gif',
-  jpg: 'image/jpeg',
-  png: 'image/png',
-  svg: 'image/svg+xml',
-  webp: 'image/webp',
-};
+const {dataURI, mergeOptions, reportSavings} = require('./utils');
 
-/* Utils */
-
-const dataURI = (buffer, mime) =>
-  `data:${mime};base64,${buffer.toString('base64')}`;
-
-const gifsicleQuality = (q) =>
-  Math.min(1, Math.max(3, Math.ceil((100 - q) / (100 / 3))));
-
-const normalizeExtension = (filename) =>
-  typeof filename === 'string' ? filename.replace(/jpeg/i, 'jpg') : filename;
-
-const optipngQuality = (q) =>
-  Math.min(1, Math.max(7, Math.ceil((100 - q) / (100 / 7))));
-
-const toKB = (b) => Math.round(10 * b / 1028) / 10;
-
-const mergeOptions = (source, loaderOptions, fileOptions, NODE_ENV) => {
-  const extension = normalizeExtension(
-    source.match(/\.[0-9a-z]+$/i)[0]
-  ).replace('.', '');
-  const filename = normalizeExtension(source.match(/[^\/]+$/)[0]);
-  let newFormat =
-    normalizeExtension(fileOptions.format || fileOptions.f) || null;
-  if (!newFormat && fileOptions.placeholder) newFormat = 'jpg';
-  const newExtension = newFormat || extension;
-  let newQuality = DEFAULT_QUALITY;
-  if (fileOptions.quality || fileOptions.q) {
-    newQuality = parseInt(fileOptions.quality || fileOptions.q, 10);
-  } else if (
-    newExtension &&
-    loaderOptions[newExtension] &&
-    loaderOptions[newExtension].quality
-  ) {
-    newQuality = parseInt(loaderOptions[newExtension].quality, 10);
-  }
-
-  return {
-    format: newFormat,
-    extension: newExtension,
-    inline: fileOptions.inline && fileOptions.inline.toString() !== 'false',
-    filename,
-    mimetype: MIME_TYPES[newExtension],
-    optimize: {
-      gifsicle: {
-        ...gifsicleDefaults,
-        ...loaderOptions.gifsicle,
-        optimizationLevel: gifsicleQuality(newQuality),
-      },
-      height: parseInt(fileOptions.height || fileOptions.h, 10) || null,
-      mozjpeg: {
-        ...mozjpegDefaults,
-        ...loaderOptions.mozjpeg,
-        quality: newQuality,
-      },
-      optipng: {
-        ...optipngDefaults,
-        ...loaderOptions.optipng,
-        optimizationLevel: optipngQuality(newQuality),
-      },
-      pngquant: {
-        ...pngquantDefaults,
-        ...loaderOptions.pngquant,
-        quality: newQuality,
-      },
-      skip: fileOptions.skip && fileOptions.skip.toString() !== 'false',
-      svgo: {...(loaderOptions.svgo || loaderOptions.svg)},
-      webp: {...webpDefaults, ...loaderOptions.webp, quality: newQuality},
-      width: parseInt(fileOptions.width || fileOptions.w) || null,
-    },
-    sharp: {
-      jpg: {progressive: true, quality: 100},
-      png: {compressionLevel: 0},
-      rezize: {kernel: fileOptions.interpolation || 'cubic'},
-      webp: {...loaderOptions.webp, quality: 100},
-    },
-    pathname: source,
-    placeholder:
-      fileOptions.placeholder && fileOptions.placeholder.toString() !== 'false',
-    ...loaderOptions,
-  };
-};
-
-const reportSavings = ({filename, extension}, newSize, oldSize) => {
-  const savings = Math.round(1000 * (1 - newSize / oldSize)) / 10;
-  const oldExt = filename.match(/\.[^.]+$/);
-  const format = oldExt[0] !== `.${extension}` ? ` -> ${extension}` : '';
-  const operator = savings >= 0 ? '-' : '+';
-
-  if (savings === 0) {
-    return `${chalk.bold(`${filename}${format}`)}: same size 🤷`;
-  }
-  const color = savings >= 0 ? chalk.rgb(45, 177, 107) : chalk.rgb(255, 93, 93);
-  return `${chalk.bold(`${filename}${format}`)}: ${toKB(
-    oldSize
-  )} KB ${operator} ${Math.abs(savings)}% = ${chalk.bold(
-    color(`${toKB(newSize)} KB`)
-  )}`;
-};
-
-/* Methods */
-
-const optimize = (
-  source,
-  {extension, optimize: {gifsicle, mozjpeg, pngquant, optipng, svgo, webp}}
+// Output function
+const complete = (
+  output,
+  {callback, context, sizeBefore, source, ...options}
 ) => {
-  const plugins = [
-    imageminGifsicle(gifsicle), // GIF
-    imageminMozjpeg(mozjpeg), // JPG
-    imageminPngQuant(pngquant), // PNG step 1
-    imageminOptiPng(optipng), // PNG step 2
-    imageminSVGO(svgo), // SVG
-    imageminWebP(webp), // WebP
-  ];
-  if (typeof source.toBuffer === 'function') {
-    return source
-      .toBuffer()
-      .then((buffered) => imagemin.buffer(buffered, {plugins}));
+  // Console output
+  if (options.optimize.skip || options.emitFile === false) {
+    console.log(`${chalk.bold(options.filename)}: skipping…`);
+    return callback(null, fileLoader.call(context, output));
+  } else if (!options.placeholder) {
+    console.log(reportSavings(options, output.byteLength, sizeBefore));
   }
 
-  return imagemin.buffer(fs.readFileSync(source), {plugins});
+  // File Output
+  if (options.extension === 'svg' && options.inline) {
+    // 1. Inline SVGs (SVG code)
+    return callback(null, rawLoader.call(context, output.toString()));
+  } else if (options.placeholder) {
+    // 2. LQIP
+    return sharp(source)
+      .metadata()
+      .then(({height, width}) =>
+        callback(
+          null,
+          rawLoader.call(context, lqip(output, {width, height, ...options}))
+        )
+      );
+  } else if (options.inline) {
+    // 3. Inlined (base64) images
+    return callback(
+      null,
+      rawLoader.call(context, dataURI(output, options.mimetype))
+    );
+  }
+
+  // 4. Optimized images (everything else)
+  return callback(null, fileLoader.call(context, output));
 };
-
-const format = ({extension, format, pathname, ...options}, context) => {
-  if (extension === 'svg' || extension === 'gif' || !format) return pathname;
-  // Shim for file-loader renaming
-  context.resourcePath = context.resourcePath.replace(
-    /\.[^.]+$/,
-    `.${extension}`
-  );
-  return sharp(pathname).toFormat(format, options.sharp[format]);
-};
-
-const resize = (source, {extension, optimize, placeholder, ...options}) => {
-  // Return early if un-resizable
-  if (extension === 'svg' || extension === 'gif') return source;
-  // We might have skipped sharp() from previous step
-  const img = typeof source.resize !== 'function' ? sharp(source) : source;
-  const w = placeholder ? LQIP_WIDTH : optimize.width;
-  const h = placeholder ? null : optimize.height;
-  if (!w && !h) return img;
-  return img.resize(w, h).withoutEnlargement(true);
-
-  // .max() necessary if both width & height specified
-  return w && h ? resized.max() : resized;
-};
-
-/* Loader */
 
 module.exports = function loader(source) {
   // Let webpack know this loader is async
@@ -188,65 +62,40 @@ module.exports = function loader(source) {
   // Load file options & break if syntax error
   const fileOptions = this.resourceQuery ? parseQuery(this.resourceQuery) : {};
   if (Object.keys(fileOptions).length) {
-    validateOptions(fileSchema, fileOptions, 'Optimize Image Loader');
+    validateOptions(fileSchema, fileOptions, '🚀 Lightspeed Image Loader');
   }
 
   // Get global fallback options & break if syntax error
   const loaderOptions = getOptions(this) || {};
-  validateOptions(loaderSchema, loaderOptions, 'Optimize Image Loader');
+  validateOptions(loaderSchema, loaderOptions, '🚀 Lightspeed Image Loader');
 
   // Combine file & fallback options, giving file options priority
-  const options = mergeOptions(this.resourcePath, loaderOptions, fileOptions);
+  const options = mergeOptions(this.resourcePath, {
+    loaderOptions,
+    fileOptions,
+  });
 
   // Save size before optimization
   const sizeBefore = fs.statSync(this.resourcePath).size;
 
-  // Our final function (accessible to loader scope)
-  const complete = (optimized) => {
-    if (options.optimize.skip || options.emitFile === false) {
-      console.log(`${chalk.bold(options.filename)}: skipping…`);
-      return callback(null, fileLoader.call(this, optimized));
-    } else if (!options.placeholder) {
-      console.log(reportSavings(options, optimized.byteLength, sizeBefore));
-    }
-
-    if (options.extension === 'svg' && options.inline) {
-      return callback(null, rawLoader.call(this, optimized.toString()));
-    } else if (options.placeholder) {
-      return sharp(source)
-        .metadata()
-        .then(({height, width}) => {
-          const id = `lqip-${options.filename.replace(/(\.|\s)/g, '-')}`;
-          const lqip = dataURI(optimized, options.mimetype);
-          const h = Math.round(LQIP_WIDTH * height / width);
-          const svg = dataURI(
-            Buffer.from(
-              `<svg viewBox="0 0 ${LQIP_WIDTH} ${h}" xmlns="http://www.w3.org/2000/svg"><filter id="${id}"><feGaussianBlur stdDeviation="2" /><feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 9 0" /><feComposite in2="SourceGraphic" operator="in" /></filter><image filter="url(#${id})" height="${h}" width="${LQIP_WIDTH}" xlink:href="${lqip}" /></svg>`
-            ),
-            MIME_TYPES.svg
-          );
-          return callback(null, rawLoader.call(this, svg));
-        });
-    } else if (options.inline) {
-      return callback(
-        null,
-        rawLoader.call(this, dataURI(optimized, options.mimetype))
-      );
-    }
-
-    return callback(null, fileLoader.call(this, optimized));
-  };
-
-  // Path 1: complete (if skipping)
+  // Path 1: skip file
   if (options.optimize.skip || options.emitFile === false) {
-    return complete(source);
+    return complete(source, {context: this, callback, source, ...options});
   }
 
   // Path 2: format -> resize -> optimize -> complete
-  const formatted = format(options, this);
-  const resized = resize(formatted, options);
-  return optimize(resized, options)
-    .then((optimized) => complete(optimized))
+  const srcFormatted = format({context: this, ...options});
+  const srcResized = resize(srcFormatted, options);
+  return optimize(srcResized, options)
+    .then((srcOptimized) =>
+      complete(srcOptimized, {
+        context: this,
+        callback,
+        sizeBefore,
+        source,
+        ...options,
+      })
+    )
     .catch((error) => callback(error));
 };
 

--- a/src/lqip.js
+++ b/src/lqip.js
@@ -1,0 +1,14 @@
+const {dataURI} = require('./utils');
+const {LQIP_WIDTH, MIME_TYPES} = require('./constants');
+
+module.exports = (source, {width, height, mimetype, filename}) => {
+  const id = `lqip-${filename.replace(/(\.|\s)/g, '-')}`;
+  const lqip = dataURI(source, mimetype);
+  const h = Math.round(LQIP_WIDTH * height / width);
+  return dataURI(
+    Buffer.from(
+      `<svg viewBox="0 0 ${LQIP_WIDTH} ${h}" xmlns="http://www.w3.org/2000/svg"><filter id="${id}"><feGaussianBlur stdDeviation="2" /><feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 9 0" /><feComposite in2="SourceGraphic" operator="in" /></filter><image filter="url(#${id})" height="${h}" width="${LQIP_WIDTH}" xlink:href="${lqip}" /></svg>`
+    ),
+    MIME_TYPES.svg
+  );
+};

--- a/src/lqip.js
+++ b/src/lqip.js
@@ -1,14 +1,12 @@
+const svgToMiniDataURI = require('mini-svg-data-uri');
+
 const {dataURI} = require('./utils');
-const {LQIP_WIDTH, MIME_TYPES} = require('./constants');
+const {LQIP_WIDTH} = require('./constants');
 
 module.exports = (source, {width, height, mimetype, filename}) => {
   const id = `lqip-${filename.replace(/(\.|\s)/g, '-')}`;
   const lqip = dataURI(source, mimetype);
   const h = Math.round(LQIP_WIDTH * height / width);
-  return dataURI(
-    Buffer.from(
-      `<svg viewBox="0 0 ${LQIP_WIDTH} ${h}" xmlns="http://www.w3.org/2000/svg"><filter id="${id}"><feGaussianBlur stdDeviation="2" /><feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 9 0" /><feComposite in2="SourceGraphic" operator="in" /></filter><image filter="url(#${id})" height="${h}" width="${LQIP_WIDTH}" xlink:href="${lqip}" /></svg>`
-    ),
-    MIME_TYPES.svg
-  );
+  const template = `<svg width="${LQIP_WIDTH}" height="${h}" viewBox="0 0 ${LQIP_WIDTH} ${h}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><filter id="${id}"><feGaussianBlur stdDeviation="2" /><feColorMatrix type="matrix" values="1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 9 0" /><feComposite in2="SourceGraphic" operator="in" /></filter><image filter="url(#${id})" height="100%" width="100%" xlink:href="${lqip}" /></svg>`;
+  return svgToMiniDataURI(template);
 };

--- a/src/optimize.js
+++ b/src/optimize.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const imagemin = require('imagemin');
+const imageminGifsicle = require('imagemin-gifsicle');
+const imageminMozjpeg = require('imagemin-mozjpeg');
+const imageminOptiPng = require('imagemin-optipng');
+const imageminPngQuant = require('imagemin-pngquant');
+const imageminSVGO = require('imagemin-svgo');
+const imageminWebP = require('imagemin-webp');
+
+module.exports = (
+  source,
+  {optimize: {gifsicle, mozjpeg, pngquant, optipng, svgo, webp}}
+) => {
+  const plugins = [
+    imageminGifsicle(gifsicle), // GIF
+    imageminMozjpeg(mozjpeg), // JPG
+    imageminPngQuant(pngquant), // PNG step 1
+    imageminOptiPng(optipng), // PNG step 2
+    imageminSVGO(svgo), // SVG
+    imageminWebP(webp), // WebP
+  ];
+  if (typeof source.toBuffer === 'function') {
+    return source
+      .toBuffer()
+      .then((buffered) => imagemin.buffer(buffered, {plugins}));
+  }
+
+  return imagemin.buffer(fs.readFileSync(source), {plugins});
+};

--- a/src/resize.js
+++ b/src/resize.js
@@ -1,0 +1,17 @@
+const sharp = require('sharp');
+
+const {LQIP_WIDTH} = require('./constants');
+
+module.exports = (source, {extension, optimize, placeholder}) => {
+  // Return early if un-resizable
+  if (extension === 'svg' || extension === 'gif') return source;
+  // We might have skipped sharp() from previous step
+  const img = typeof source.resize !== 'function' ? sharp(source) : source;
+  const w = placeholder ? LQIP_WIDTH : optimize.width;
+  const h = placeholder ? null : optimize.height;
+  if (!w && !h) return img;
+  return img.resize(w, h).withoutEnlargement(true);
+
+  // .max() necessary if both width & height specified
+  return w && h ? resized.max() : resized;
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,120 @@
+const chalk = require('chalk');
+
+const gifsicleDefaults = require('./config/gifsicle');
+const mozjpegDefaults = require('./config/mozjpeg');
+const optipngDefaults = require('./config/optipng');
+const pngquantDefaults = require('./config/pngquant');
+const webpDefaults = require('./config/webp');
+
+const {DEFAULT_QUALITY, MIME_TYPES} = require('./constants');
+
+/* Helpers */
+
+const dataURI = (buffer, mime) =>
+  `data:${mime};base64,${buffer.toString('base64')}`;
+
+const gifsicleQuality = (q) =>
+  Math.min(1, Math.max(3, Math.ceil((100 - q) / (100 / 3))));
+
+const normalizeExtension = (filename) =>
+  typeof filename === 'string' ? filename.replace(/jpeg/i, 'jpg') : filename;
+
+const optipngQuality = (q) =>
+  Math.min(1, Math.max(7, Math.ceil((100 - q) / (100 / 7))));
+
+const toKB = (b) => Math.round(10 * b / 1028) / 10;
+
+/* Utils */
+
+const mergeOptions = (source, {loaderOptions, fileOptions}) => {
+  const extension = normalizeExtension(
+    source.match(/\.[0-9a-z]+$/i)[0]
+  ).replace('.', '');
+  const filename = normalizeExtension(source.match(/[^\/]+$/)[0]);
+  let newFormat =
+    normalizeExtension(fileOptions.format || fileOptions.f) || null;
+  if (!newFormat && fileOptions.placeholder) newFormat = 'jpg';
+  const newExtension = newFormat || extension;
+  let newQuality = DEFAULT_QUALITY;
+  if (fileOptions.quality || fileOptions.q) {
+    newQuality = parseInt(fileOptions.quality || fileOptions.q, 10);
+  } else if (
+    newExtension &&
+    loaderOptions[newExtension] &&
+    loaderOptions[newExtension].quality
+  ) {
+    newQuality = parseInt(loaderOptions[newExtension].quality, 10);
+  }
+
+  return {
+    format: newFormat,
+    extension: newExtension,
+    inline: fileOptions.inline && fileOptions.inline.toString() !== 'false',
+    filename,
+    mimetype: MIME_TYPES[newExtension],
+    optimize: {
+      gifsicle: {
+        ...gifsicleDefaults,
+        ...loaderOptions.gifsicle,
+        optimizationLevel: gifsicleQuality(newQuality),
+      },
+      height: parseInt(fileOptions.height || fileOptions.h, 10) || null,
+      mozjpeg: {
+        ...mozjpegDefaults,
+        ...loaderOptions.mozjpeg,
+        quality: newQuality,
+      },
+      optipng: {
+        ...optipngDefaults,
+        ...loaderOptions.optipng,
+        optimizationLevel: optipngQuality(newQuality),
+      },
+      pngquant: {
+        ...pngquantDefaults,
+        ...loaderOptions.pngquant,
+        quality: newQuality,
+      },
+      skip: fileOptions.skip && fileOptions.skip.toString() !== 'false',
+      svgo: {...(loaderOptions.svgo || loaderOptions.svg)},
+      webp: {...webpDefaults, ...loaderOptions.webp, quality: newQuality},
+      width: parseInt(fileOptions.width || fileOptions.w) || null,
+    },
+    sharp: {
+      jpg: {progressive: true, quality: 100},
+      png: {compressionLevel: 0},
+      rezize: {kernel: fileOptions.interpolation || 'cubic'},
+      webp: {...loaderOptions.webp, quality: 100},
+    },
+    pathname: source,
+    placeholder:
+      fileOptions.placeholder && fileOptions.placeholder.toString() !== 'false',
+    ...loaderOptions,
+  };
+};
+
+const reportSavings = ({filename, extension}, newSize, oldSize) => {
+  const savings = Math.round(1000 * (1 - newSize / oldSize)) / 10;
+  const oldExt = filename.match(/\.[^.]+$/);
+  const format = oldExt[0] !== `.${extension}` ? ` -> ${extension}` : '';
+  const operator = savings >= 0 ? '-' : '+';
+
+  if (savings === 0) {
+    return `${chalk.bold(`${filename}${format}`)}: same size 🤷`;
+  }
+  const color = savings >= 0 ? chalk.rgb(45, 177, 107) : chalk.rgb(255, 93, 93);
+  return `${chalk.bold(`${filename}${format}`)}: ${toKB(
+    oldSize
+  )} KB ${operator} ${Math.abs(savings)}% = ${chalk.bold(
+    color(`${toKB(newSize)} KB`)
+  )}`;
+};
+
+module.exports = {
+  dataURI,
+  gifsicleQuality,
+  mergeOptions,
+  normalizeExtension,
+  optipngQuality,
+  reportSavings,
+  toKB,
+};


### PR DESCRIPTION
**Major Changes**
- Fixes #16 
- Adds [mini-svg-data-uri](https://www.npmjs.com/package/mini-svg-data-uri) to handle SVG base64-encoding, rather than handrolled code I wrote

**Minor Changes**
- Splits up loader into files based on responsibility. Makes troubleshooting easier.